### PR TITLE
Remove temporary stuff from automounting guide

### DIFF
--- a/macros_tmpls/automounting_guide_depr.md
+++ b/macros_tmpls/automounting_guide_depr.md
@@ -1,10 +1,9 @@
 !!! warning "Deprecation notice"
 
-    {# TODO: Remove :testing mention whenever gets merged into main #}
     {# TODO: Write section explaining partition labeling requirements and procedure #}
-    15/03/2025 ~ If you are using the `:testing` branch, this procedure is no longer needed as by [commit `0982eda`](https://github.com/ublue-os/bazzite/commit/0982eda834e2dee52497b9758f6b99711eb298de). [`ublue-os-media-automount-udev`](https://github.com/ublue-os/packages/tree/main/packages/ublue-os-media-automount-udev) will handle automounting in non-removable devices (BTRFS and ext4 supported only).
+    If you are using the latest version of Bazzite, this procedure is no longer needed. [`ublue-os-media-automount-udev`](https://github.com/ublue-os/packages/tree/main/packages/ublue-os-media-automount-udev) will handle automounting in non-removable devices.
 
-    Only labeled partitions will be automounted.
+    Only **labeled** partitions with the **ext4** or **BTRFS** filesystem will be automounted.
     
     Partitions will be mounted under `/run/media/system/PARTITION_LABEL`.
     You can place a custom named shortcut to the partition with:


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->

Remove temporary outdated bits from auto-mounting guide.