### PR TITLE
Update paragraph regarding KDE themes and discover

### DIFF
--- a/src/General/Desktop_Environment_Tweaks.md
+++ b/src/General/Desktop_Environment_Tweaks.md
@@ -13,7 +13,11 @@ tags:
 
 KDE Plasma is the default Bazzite desktop environment and is highly customizable. One of the various customization that can be done is installing custom styles, cursors, and icons to your system with custom themes made by the community.
 
-Do **not** install themes with the built-in KDE system settings installer since it may not install properly because the filesystem is slightly different than most Linux operating systems. Install themes manually into your Home directory and follow instructions from the author if necessary.
+The downloading of themes through Discover has been disabled due to issues regarding the slow loading of search results, and compatibility issues with themes written for old versions of KDE. This may change in the future; in the mean time, you can try to install themes through the KDE system settings, or install them manually.
+
+!!! note
+
+    Themes installed through the System Settings are installed into `~/.local/share/plasma`; to uninstall them, you may need to manually delete the folders associated with the installed themes manually.
 
 ![Directory|401x207, 75%](../img/Directory.png)
 


### PR DESCRIPTION
As talked about in [this convo](https://discord.com/channels/1072614816579063828/1237926270151688192/1372576370323882086) in the Universal Blue discord server.

The reason the themes are not shown in Discover is not related to the file system structure, but rather related with performance and KDE compatibility issues. This PR updates the docs to clarify this.
I added the note about potentially needing to manually uninstall themes because it seemed to be slightly glitched in not always allowing me to uninstall them; as far as I can tell, this is not a Bazzite issue, but rather some other KDE bug I have not fully debugged