### PR TITLE
Removed framerate pacing bullet point for nvidia hardware

### DIFF
--- a/src/Handheld_and_HTPC_edition/quirks.md
+++ b/src/Handheld_and_HTPC_edition/quirks.md
@@ -199,9 +199,8 @@ https://www.youtube.com/watch?v=gE1ff72g2Gk
     This only affects the `bazzite-deck-nvidia` images.
 
 - "Enable GPU accelerated rendering in web views (requires restart)" must be enabled in the Steam settings for better performance in the UI.
-- Resolutions above 2560x1440 will cause game-breaking graphical artifacts.
+  - Resolutions above 2560x1440 will cause game-breaking graphical artifacts using this setting.
 - HDR can cause game-breaking graphical artifacts.
-- Frame pacing is a mess due to the proprietary Nvidia drivers [shipping a broken version of the Vulkan extension that Steam Gaming Mode requires for full functionality](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_present_wait.html).
 
 <hr>
 


### PR DESCRIPTION
Open to changes...
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
