### PR TITLE
Add link for Balena Etcher

### DIFF
--- a/macros_tmpls/installer_requirements.md
+++ b/macros_tmpls/installer_requirements.md
@@ -3,6 +3,7 @@
 - Software to flash the image:
 <small>Make sure to properly eject the drive after flashing the ISO to it</small>
   - Fedora Media Writer
-    <small>[Windows .exe](https://github.com/FedoraQt/MediaWriter/releases/latest), [Linux flatpak](https://flathub.org/apps/org.fedoraproject.MediaWriter)</small>
+    <small>[Windows/Mac](https://github.com/FedoraQt/MediaWriter/releases/latest), [Linux flatpak](https://flathub.org/apps/org.fedoraproject.MediaWriter)</small>
   - [Ventoy](https://www.ventoy.net/en/index.html)
   - [Rufus](https://rufus.ie/en/)
+  - [Etcher](https://etcher.balena.io/)


### PR DESCRIPTION
I know Bazzite doesn't support Mac hardware at the moment, but that doesn't mean people won't flash their usb from their Mac. For instance, I just had to because my Linux laptop won't boot.

Fedora Media Writer does support Intel/Arm Macs so I changed that link to indicate that. Unfortunately they don't sign their binaries so it's not beginner friendly: https://github.com/FedoraQt/MediaWriter/issues/710

I added a link to Belena Etcher, which has a great UI and works on macs. It is open source but at least at one point apparently tracked your data: https://www.gameindustry.eu/reviews/balenaetcher/

Nothing really is a perfect solution but I'm pretty sure some of the folks curious about Bazzite have a mac.
