### PR TITLE
docs: Add instruction to backup fstab and how to restore zram-generator.conf

### DIFF
--- a/src/Advanced/swapfile.md
+++ b/src/Advanced/swapfile.md
@@ -40,7 +40,7 @@ sudo swapon /var/swap/swapfile
 Backup your fstab file with:
 
 ```
-sudo cp  /etc/fstab.bak
+sudo cp /etc/fstab /etc/fstab.bak
 ```
 
 Then, edit fstab with this **command**:
@@ -60,7 +60,7 @@ Then add the following **line of code** to fstab:
 In case of any error, you may restore from your backup with this:
 
 ```
-sudo cp  /etc/fstab.bak /etc/fstab
+sudo cp /etc/fstab.bak /etc/fstab
 ```
 
 ## Disable zram

--- a/src/Advanced/swapfile.md
+++ b/src/Advanced/swapfile.md
@@ -37,7 +37,13 @@ sudo swapon /var/swap/swapfile
 
 ## Adding it to fstab
 
-Edit fstab with this **command**:
+Backup your fstab file with:
+
+```
+sudo cp  /etc/fstab.bak
+```
+
+Then, edit fstab with this **command**:
 
 ```
 sudo nano /etc/fstab
@@ -51,10 +57,27 @@ Then add the following **line of code** to fstab:
 
 `/var/swap/swapfile none swap defaults,nofail 0 0`
 
+In case of any error, you may restore from your backup with this:
+
+```
+sudo cp  /etc/fstab.bak /etc/fstab
+```
+
 ## Disable zram
+
 ```
 echo "" | sudo tee /etc/systemd/zram-generator.conf
 ```
 
 ## Reboot
 Reboot your device to apply the changes made above.
+
+## Reverting changes and restoring zram
+
+Should you want to restore the default, copy the zram-generator.conf from `/usr/etc/systemd/zram-generator.conf`:
+
+```
+sudo cp /usr/etc/systemd/zram-generator.conf /etc/systemd/zram-generator.conf
+```
+
+And then restore your original fstab file as shown above.


### PR DESCRIPTION
Best to habituate backing up before editing system configs.

Not entirely sure about zram-generator.conf -- IIRC the default /etc files should always be /usr/etc but I can't check on an actual install right now because I'm at work. Someone correct me if I'm wrong.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
