### PR TITLE
ujust should be preferred over a flatpak

### DIFF
--- a/src/Installing_and_Managing_Software/index.md
+++ b/src/Installing_and_Managing_Software/index.md
@@ -10,8 +10,8 @@ title: Installing and Managing Applications
 
 ### **Package formats ranked from most recommended to least recommended for daily usage**:
 
-1. [**Flatpak**](./Flatpak.md) (_Graphical Applications_) - Universal package format using a permissions-based model and should be used for most graphical applications.
-2. [**`ujust`**](./ujust.md) (_Convenience Commands_) - Custom scripts maintained by Bazzite & Universal Blue contributors that can install applications.
+1. [**`ujust`**](./ujust.md) (_Convenience Commands_) - Custom scripts maintained by Bazzite & Universal Blue contributors that can install applications.
+2. [**Flatpak**](./Flatpak.md) (_Graphical Applications_) - Universal package format using a permissions-based model and should be used for most graphical applications.
 3. [**Homebrew**](./Homebrew.md) (_Command-Line Tools_) - Install applications intended to run inside of the terminal (CLI/TUI).
 4. [**Quadlet**](./Quadlet.md)  (_Services_) - Run containerized applications as a [systemd service](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/7/html/system_administrators_guide/chap-managing_services_with_systemd#sect-Managing_Services_with_systemd-Services).
 5. [**Distrobox Containers**](./Distrobox.md) (_Linux Packages & Development Workflows_) - Access to most Linux package managers for software that do not support Flatpak and Homebrew and for use as development boxes.


### PR DESCRIPTION
ujust should be preferred over a flatpak. 

LACT as an example here: Won't function properly if just installing just the flatpak.