### PR TITLE
feat: Use DeepWiki LLM to answer users questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/bazzite-org/docs.bazzite.gg)
+
 # Contributing to Bazzite MkDocs documentation
 
 - [Contributing to Bazzite MkDocs documentation](#contributing-to-bazzite-mkdocs-documentation)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,6 +122,7 @@ markdown_extensions:
 
 nav:
   - index.md
+  - '«ChatGPT, how to ...?»': https://deepwiki.com/bazzite-org/docs.bazzite.gg
   - FAQ: "General/FAQ.md"
   - Installation:
          - "Setup Guide": General/Installation_Guide/index.md


### PR DESCRIPTION
Allows Deepwiki to scan the documentation and provide users with a ChatGPT-like chatbox to answer questions.