### PR TITLE
Update 'Show  Detailed Init Logs During Boot' ( plymouth_init.md ) Wiki Page for Better Readability for people with limited technical info

### DIFF
--- a/src/Advanced/plymouth_init.md
+++ b/src/Advanced/plymouth_init.md
@@ -4,9 +4,8 @@ authors:
   - "@dkolb"
   - "@nicknamenamenick"
 tags:
-  -  Guide
+  - Guide
 ---
-
 
 See the init log show if services are functional when your device boots:
 
@@ -17,6 +16,7 @@ See the init log show if services are functional when your device boots:
 ```command
 sudo plymouth-set-default-theme details
 ```
+
 Alternatively, create `/etc/plymouth/plymouthd.conf` manually
 
 ### 2- Regenerate Initramfs & Reboot to Enable Theme Change

--- a/src/Advanced/plymouth_init.md
+++ b/src/Advanced/plymouth_init.md
@@ -12,10 +12,14 @@ See the init log show if services are functional when your device boots:
 
 ![Plymouth](../img/plymouth.png)
 
+### 1- Change Initramfs Theme to Enable Detailed Init Logs:
+
 ```command
 sudo plymouth-set-default-theme details
 ```
 Alternatively, create `/etc/plymouth/plymouthd.conf` manually
+
+### 2- Regenerate Initramfs & Reboot to Enable Theme Change
 
 ```command
 sudo rpm-ostree initramfs --enable --reboot


### PR DESCRIPTION
Updated  'Show  Detailed Init Logs During Boot' Wiki page with Better readability for people to not miss extra steps. (Better for people with limited technical info)

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
