### PR TITLE
Fix VPN guide to match current documentation uniformity

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -143,9 +143,9 @@ nav:
       - "Issues & Resolutions": "General/issues_and_resolutions.md"
       - "Reporting Bugs": General/reporting_bugs.md
       - "Desktop Environment Tweaks": General/Desktop_Environment_Tweaks.md
+      - "VPN Setup": General/VPN.md
       - "Community Resources": General/community-links.md
       - "Uninstalling Bazzite": General/uninstalling-bazzite.md
-      - "VPN Setup": General/VPN.md
       - "Repository Information (External)":
         - "README": https://github.com/ublue-os/bazzite/blob/main/README.md
         - "Security Policy": https://github.com/ublue-os/bazzite/blob/main/SECURITY.md

--- a/src/General/index.md
+++ b/src/General/index.md
@@ -10,6 +10,7 @@ title: General Documentation
 - [**Issues & Resolution**](/General/issues_and_resolutions.md)
 - [**Reporting Bugs**](/General/reporting_bugs.md)
 - [**Desktop Environment Tweaks**](/General/Desktop_Environment_Tweaks.md)
+- [**VPN Setup**](/General/VPN.md)
 - [**Community Resources**](/General/community-links.md)
 - [**Uninstalling Bazzite**](/General/uninstalling-bazzite.md)
 


### PR DESCRIPTION
Moves the newly added VPN guide above "Uninstalling Bazzite" in the sidebar and adds it to the 'general index' page.
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
