### PR TITLE
Reorganize social platforms page

### DIFF
--- a/src/Resources.md
+++ b/src/Resources.md
@@ -2,18 +2,18 @@
 title: Social Platforms
 ---
 
+## [:simple-discourse: Project News](https://universal-blue.discourse.group/tag/bazzite-news)
+
 ## [:simple-discord: Discord](https://discord.gg/WEu6BdFEtp) <sup>([Answer Overflow](https://www.answeroverflow.com/c/1072614816579063828/1143023993041993769))</sup>
 
-## [:simple-discourse: Forums](https://universal-blue.discourse.group/c/bazzite/5)
-
 ## [:simple-reddit: Reddit](https://www.reddit.com/r/bazzite) <sup>([Redlib](https://redlib.perennialte.ch/r/Bazzite))</sup>
-
-## [:simple-lemmy: Lemmy](https://lemmy.world/c/bazzite)
-
-## [:simple-mastodon: Mastodon](https://fosstodon.org/@UniversalBlue)
 
 ## [:simple-bluesky: Bluesky](https://bsky.app/profile/bazzite.gg)
 
 ## [:simple-x: X/Twitter](https://x.com/bazzite_gg) <sup>([Nitter](https://xcancel.com/bazzite_gg))</sup>
+
+## [:simple-mastodon: Mastodon](https://fosstodon.org/@UniversalBlue)
+
+## [:simple-lemmy: Lemmy](https://lemmy.world/c/bazzite)
 
 ## [:simple-steam: Steam Group](https://steamcommunity.com/groups/Bazzite)


### PR DESCRIPTION
Feel free to also change this in a way that makes sense.  I just wanted to make sure that Discourse was no longer named 'forums'.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
