### PR TITLE
feat: Add Troubleshooting section and troubleshooting item to Auto-Mounting_Secondary_Drives.md

### DIFF
--- a/src/Advanced/Auto-Mounting_Secondary_Drives.md
+++ b/src/Advanced/Auto-Mounting_Secondary_Drives.md
@@ -45,8 +45,24 @@ Append `,user,exec` at the end if doesnt work properly
 
 ![](../img/GNOME_Mount_Options_new.2.png)
 
-## Emergency Mode After Mounting?
+## Troubleshooting
+
+### Emergency Mode after mounting?
 
 This video tutorial shows how to recover from your mounting mistakes.
 
 https://www.youtube.com/watch?v=-2wca_0CpXY
+
+### Drives will not auto-mount despite being BTRS/ext4 (Requests authentication every boot to mount)
+
+1. Mount the target disk(s).
+
+2. Open Gnome Disks and navigate to the target disk.
+
+3. Click on Additional Partition Options > Edit Mount Options.
+
+4. Ensure "User Session Defaults" is FALSE and "Mount at system startup" is TRUE the click "Ok"
+
+5. Repeat for any additional disks. You can can confirm this worked by checking your Fstab file and seeing that the appropriate UUIDs have been added. `sudo cat /etc/fstab`
+
+


### PR DESCRIPTION
Added some troubleshooting steps to the documentation src/Advanced/Auto-Mounting_Secondary_Drives.md to for BTRS/Ext4 drives that wont automount.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
