### PR TITLE
fix: Update the homebrew page with the information that there are casks that work on Linux

### DIFF
--- a/src/Installing_and_Managing_Software/Homebrew.md
+++ b/src/Installing_and_Managing_Software/Homebrew.md
@@ -18,7 +18,7 @@ tags:
 
     Any package that requires root privileges will either need a rootful Distrobox container or has to be layered with `rpm-ostree`.
 
-Homebrew is a package manager that installs packages into their own prefix. It is primarily used for command-line interface (CLI) and terminal user interface (TUI) applications. Homebrew can also install graphical applications using the `--cask` flag, but these are usually available only on MacOS because support for casks on Linux is still developing.
+Homebrew is a package manager that installs packages into their own prefix. It is primarily used for command-line interface (CLI) and terminal user interface (TUI) applications. Homebrew can also install graphical applications using the `--cask` flag, but most are for macOS as support for casks on Linux is still developing.
 
 Install packages in a host terminal with this **command**:
 

--- a/src/Installing_and_Managing_Software/Homebrew.md
+++ b/src/Installing_and_Managing_Software/Homebrew.md
@@ -1,6 +1,7 @@
 ---
 authors:
   - "@nicknamenamenick"
+  - "@tired-runner"
 tags:
   -  Software
 ---
@@ -17,7 +18,7 @@ tags:
 
     Any package that requires root privileges will either need a rootful Distrobox container or has to be layered with `rpm-ostree`.
 
-Homebrew is a package manager that installs packages to their own prefix, and is used strictly for command-line interface (CLI) and terminal user interface (TUI) applications. Note that graphical applications via the `--cask` flag are Mac specific and do not work on Linux.
+Homebrew is a package manager that installs packages into their own prefix. It is primarily used for command-line interface (CLI) and terminal user interface (TUI) applications. Homebrew can also install graphical applications using the `--cask` flag, but these are usually available only on MacOS because support for casks on Linux is still developing.
 
 Install packages in a host terminal with this **command**:
 


### PR DESCRIPTION
This page sometimes confuses people on the discord when a Linux compatible cask is recommended so clarify the situation a bit.

<img width="1280" height="610" alt="Screenshot From 2025-10-02 12-00-41" src="https://github.com/user-attachments/assets/60e5f2e1-a0e5-4f8d-8f2d-56a351b24016" />
